### PR TITLE
Add Tag/Untag Role/Policy permissions to the credentials and intents operator - to support IAM tag instead of delete policy

### DIFF
--- a/aws-iam-operator-setup-template.yaml
+++ b/aws-iam-operator-setup-template.yaml
@@ -122,6 +122,7 @@ Resources:
               - "iam:DeletePolicy"
               - "iam:DeletePolicyVersion"
               - "iam:TagPolicy"
+              - "iam:UntagPolicy"
               - "iam:DetachRolePolicy"
               - "ec2:DescribeInstances"
               - "eks:DescribeCluster"
@@ -165,6 +166,9 @@ Resources:
               - "iam:DeleteRole"
               - "iam:DetachRolePolicy"
               - "iam:TagRole"
+              - "iam:TagPolicy"
+              - "iam:UntagRole"
+              - "iam:UntagPolicy"
             Resource: "*"
           - Effect: Deny
             Action:

--- a/terraform/modules/aws-iam-operator-setup/resource.tf
+++ b/terraform/modules/aws-iam-operator-setup/resource.tf
@@ -109,6 +109,7 @@ resource "aws_iam_policy" "intents_operator_policy" {
             "iam:DeletePolicy",
             "iam:DeletePolicyVersion",
             "iam:TagPolicy",
+            "iam:UntagPolicy",
             "iam:DetachRolePolicy",
             "ec2:DescribeInstances",
             "eks:DescribeCluster"
@@ -171,7 +172,10 @@ resource "aws_iam_policy" "credentials_operator_policy" {
             "iam:DeletePolicyVersion",
             "iam:DeleteRole",
             "iam:DetachRolePolicy",
-            "iam:TagRole"
+            "iam:TagRole",
+            "iam:TagPolicy",
+            "iam:UntagRole",
+            "iam:UntagPolicy",
           ]
           Resource = "*"
         },


### PR DESCRIPTION
### Description

Add Tag/Untag Role/Policy permissions to the credentials and intents operator - to support IAM tagging instead of deletion.

### References

https://github.com/otterize/credentials-operator/pull/111/files
https://github.com/otterize/intents-operator/pull/361/
https://github.com/otterize/intents-operator/issues/366
https://github.com/otterize/credentials-operator/issues/112

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
