### PR TITLE
DEV-4204: Add AWS metadata integration template

### DIFF
--- a/aws-metadata-integration-setup-template.yaml
+++ b/aws-metadata-integration-setup-template.yaml
@@ -4,13 +4,9 @@ Metadata:
   Source: https://github.com/otterize/setup/aws-metadata-integration-setup-template.yaml
 
 Parameters:
-  OtterizeAccountId:
-    Type: String
-    Description: The AWS account ID that can assume this role
-
   ExternalId:
     Type: String
-    Description: An external ID to provide additional security in the role assumption
+    Description: DO NOT MODIFY! - A unique ID Otterize has to provide on role assumption for additional security
 
 Resources:
   OtterizeMetadataIntegrationRole:
@@ -22,7 +18,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${OtterizeAccountId}:root
+              AWS: !Sub arn:aws:iam::353146681200:root
             Action: sts:AssumeRole
             Condition:
               StringEquals:

--- a/aws-metadata-integration-setup-template.yaml
+++ b/aws-metadata-integration-setup-template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: CloudFormation template to create a role with read-only permissions to EC2, EKS, RDS, Route53, and S3 services, and allow assumption by a specific AWS account with an external ID
+Description: Enables Otterize's AWS Visibility Integration - creates a read-only role assumable by Otterize
 Metadata:
   Source: https://github.com/otterize/setup/aws-metadata-integration-setup-template.yaml
 

--- a/aws-metadata-integration-setup-template.yaml
+++ b/aws-metadata-integration-setup-template.yaml
@@ -16,6 +16,7 @@ Resources:
   OtterizeMetadataIntegrationRole:
     Type: 'AWS::IAM::Role'
     Properties:
+      RoleName: OtterizeMetadataCollectorRole
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/aws-metadata-integration-setup-template.yaml
+++ b/aws-metadata-integration-setup-template.yaml
@@ -31,7 +31,19 @@ Resources:
               - sts:TagSession
       Path: "/"
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/ReadOnlyAccess
+        # ViewOnlyAccess is considered much more secure than ReadOnlyAccess, as it doesn't allow reading actual data (such as S3 objects)
+        - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+      Policies:
+        - PolicyName: 'EksViewOnlyAccess'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: 'Allow'
+                Action:
+                  - 'eks:ListClusters'
+                  - 'eks:DescribeCluster'
+                Resource: '*'
 
 Outputs:
   RoleArn:

--- a/aws-metadata-integration-setup-template.yaml
+++ b/aws-metadata-integration-setup-template.yaml
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template to create a role with read-only permissions to EC2, EKS, RDS, Route53, and S3 services, and allow assumption by a specific AWS account with an external ID
+Metadata:
+  Source: https://github.com/otterize/setup/aws-metadata-integration-setup-template.yaml
+
+Parameters:
+  OtterizeAccountId:
+    Type: String
+    Description: The AWS account ID that can assume this role
+
+  ExternalId:
+    Type: String
+    Description: An external ID to provide additional security in the role assumption
+
+Resources:
+  OtterizeMetadataIntegrationRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${OtterizeAccountId}:root
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref ExternalId
+      Path: "/"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/ReadOnlyAccess
+
+Outputs:
+  RoleArn:
+    Description: The ARN of the read-only role
+    Value: !GetAtt OtterizeMetadataIntegrationRole.Arn
+    Export:
+      Name: OtterizeMetadataIntegrationRoleArn

--- a/aws-metadata-integration-setup-template.yaml
+++ b/aws-metadata-integration-setup-template.yaml
@@ -23,6 +23,12 @@ Resources:
             Condition:
               StringEquals:
                 sts:ExternalId: !Ref ExternalId
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::353146681200:root
+            Action:
+              - sts:SetSourceIdentity
+              - sts:TagSession
       Path: "/"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/ReadOnlyAccess


### PR DESCRIPTION
### Description

Similarly to the template for the AWS IAM operator, this new template should be deployed within the customer's account in order to allow Otterize to collect metadata on existing cloud resources.

This basically creates a role with readonly permissions, which is assumable by Otterize's account